### PR TITLE
The settings listed here were moved from simpleavatar/__init__.py to simp

### DIFF
--- a/simpleavatar/templatetags/avatar_tags.py
+++ b/simpleavatar/templatetags/avatar_tags.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User
 from django.utils.translation import ugettext as _
 from django.utils.hashcompat import md5_constructor
 
-from simpleavatar import AVATAR_DEFAULT_URL, AVATAR_GRAVATAR_BACKUP, AVATAR_GRAVATAR_DEFAULT
+from simpleavatar.settings import AVATAR_DEFAULT_URL, AVATAR_GRAVATAR_BACKUP, AVATAR_GRAVATAR_DEFAULT
 from simpleavatar.models import avatar_thumbnail_exists, avatar_thumbnail_url
 
 register = template.Library()


### PR DESCRIPTION
The settings listed here were moved from simpleavatar/**init**.py to simpleavatar/settings.py but the templatetags weren't fixed.
